### PR TITLE
Extra functionality for Tardis commandline.

### DIFF
--- a/bin/tardis
+++ b/bin/tardis
@@ -35,6 +35,7 @@ sub run-program() {
     @ticks = $d.ticks;
     unless @ticks {
         say "No ticks registered. Quitting.";
+        debug();
         exit;
     }
 }
@@ -44,19 +45,19 @@ say "# Finished. Ticks: 0..", @ticks.end;
 
 while defined(my $cmd = prompt "TICK $current-tick/{@ticks.end}> ") {
     given $cmd {
-        when /^ \s* $/       { }
+        when /^ \s* $/     { }
         when 'look'          { look() }
         when 'step'          { step() }
         when 'n'             { step() }
-        when /^go\s+(\d+)$/  { go(+$0) }
-        when /^rewrite\s+(.+)$/ { rewrite(~$0) }
-        when 'help'          { help() }
+        when /^ go \s+ (\d+) $/  { go(+$0) }
+        when /^ rewrite \s+ (.+) $/ { rewrite(~$0) }
+        when /^ help [\s+ (\N+)]? $/ { help(~$0) }
         when 'quit'          { quit() }
         when 'q'             { quit() }
         when 'exit'          { quit() }
         when 'debug'         { debug() }
 
-        default              { say  "Sorry, unrecognized command." }
+        default              { say  "Sorry, unrecognized command. (type `help')" }
     }
 }
 
@@ -97,18 +98,33 @@ sub rewrite(Str $line is copy) {
     $program = @proglines.join(';');
     say "Rewrite of time successful. Realigning the rest of the program..."; 
     run-program();
-    say "No paradoxes occurred. You may continue."
+    say "No paradoxes occurred. You may continue.";
 }
 
-sub help() {
-    say "Tardis debugging commands:
+sub help($topic) {
+    given $topic {
+        when "look" { say "syntax: look
+    when this command is executed, Tardis will look at all the variables in your program at that particular tick and show you their values. Many other commands in Tardis will run `look' at some point."; }
+        when "step" { say "syntax: step
+    This command will go to the next tick in the program. Afterwards, `look' will be run so you can see what happens at this moment in time. If you reached the end of the timeline, the command will stop and let you continue using Tardis. This command is equivalent to go 1."; }
+        when "go" { say "syntax: go N    where N is a number.
+    `go' will jump to a specific tick in the timeline. If the point you wish to jump to is beyond the range of the timeline, the command will quit running (for the program you put in Tardis, this range is 0..{@ticks.end}). Tardis will still be running however. After jumping to that specific tick in the timeline, the command will `look'."; }
+        when "rewrite" { say "syntax: rewrite STRING
+    The `rewrite' command will rewrite the current tick with STRING. Afterwards, the program will be recompiled and rerun. Invalid P6 code will stop Tardis from running."; }
+        when "help" { say "syntax: help [COMMAND]
+    This displays help information for COMMAND. If no COMMAND is specified, a list of all the available commands and a brief list of what each command does."; }
+        #XXX add quit/exit/q help, although the need for anything more complex than what the overview says is questionable.
+        default { say "Tardis debugging commands:
 look    View the state of all variables in the program.
 step    Goes to the next tick in the program, then `look's.
 go N    Goes to tick N in the program, then  `look's.
+rewrite Rewrites the current tick, then updates the rest of the program.
 help    Display this help message.
 quit
 exit
-q       exit Tardis.";
+q       exit Tardis.
+  for more details on various commands, type help [command]";}
+    }
 }
 
 sub quit() {
@@ -116,6 +132,7 @@ sub quit() {
 }
 
 sub debug() {
-    say $program.perl;
-    say @ticks.perl;
+    say "Tardis DEBUG INFO (for Tardis devs):
+{$program.perl}
+{@ticks.perl}";
 }

--- a/bin/tardis
+++ b/bin/tardis
@@ -14,37 +14,47 @@ else {
     die "Usage: `$*PROGRAM_NAME <file>` or `$*PROGRAM_NAME -e '<program>'`";
 }
 
-my Yapsi::Compiler $c .= new;
-my Tardis::Debugger $d .= new;
+my $origprogram = $program; # in case we need the original copy later
 
-try {
-    say "# Compiling...";
-    my @sic = $c.compile($program);
-    warn $_ for $c.warnings;
+my @ticks;
+run-program();
 
-    say "# Running...";
-    $d.run(@sic);
-}
-say $! if $!;
-
-my @ticks = $d.ticks;
-unless @ticks {
-    say "No ticks registered. Quitting.";
-    exit;
+sub run-program() {
+    my Yapsi::Compiler $c .= new;
+    my Tardis::Debugger $d .= new;
+    try {
+        say "# Compiling...";
+        my @sic = $c.compile($program);
+        warn $_ for $c.warnings;
+        
+        say "# Running...";
+        $d.run(@sic);
+    }
+    say $! if $!;
+    
+    @ticks = $d.ticks;
+    unless @ticks {
+        say "No ticks registered. Quitting.";
+        exit;
+    }
 }
 
 my $current-tick = 0;
 say "# Finished. Ticks: 0..", @ticks.end;
 
-while defined(my $cmd = prompt '> ') {
+while defined(my $cmd = prompt "TICK $current-tick/{@ticks.end}> ") {
     given $cmd {
         when /^ \s* $/       { }
         when 'look'          { look() }
-        when 'step'          { step() } 
+        when 'step'          { step() }
         when 'n'             { step() }
         when /^go\s+(\d+)$/  { go(+$0) }
+        when /^rewrite\s+(.+)$/ { rewrite(~$0) }
+        when 'help'          { help() }
         when 'quit'          { quit() }
         when 'q'             { quit() }
+        when 'exit'          { quit() }
+        when 'debug'         { debug() }
 
         default              { say  "Sorry, unrecognized command." }
     }
@@ -75,7 +85,37 @@ multi sub go(Num $tick) {
     look();
 }
 
+sub rewrite(Str $line is copy) {
+    if $line.split('')[*-1] == ';' {
+        $line.chop;
+    }
+    if $current-tick == 0 {
+        say 'You cannot rewrite tick 0; this is the "before execution" tick.';
+    }
+    my @proglines = $program.split(';');
+    @proglines[$current-tick - 1] = $line;
+    $program = @proglines.join(';');
+    say "Rewrite of time successful. Realigning the rest of the program..."; 
+    run-program();
+    say "No paradoxes occurred. You may continue."
+}
+
+sub help() {
+    say "Tardis debugging commands:
+look    View the state of all variables in the program.
+step    Goes to the next tick in the program, then `look's.
+go N    Goes to tick N in the program, then  `look's.
+help    Display this help message.
+quit
+exit
+q       exit Tardis.";
+}
+
 sub quit() {
     exit;
 }
 
+sub debug() {
+    say $program.perl;
+    say @ticks.perl;
+}

--- a/bin/tardis
+++ b/bin/tardis
@@ -88,7 +88,7 @@ multi sub go(Num $tick) {
 
 sub rewrite(Str $line is copy) {
     if $line.split('')[*-1] == ';' {
-        $line.chop;
+        $line .= chop;
     }
     if $current-tick == 0 {
         say 'You cannot rewrite tick 0; this is the "before execution" tick.';

--- a/bin/tardis
+++ b/bin/tardis
@@ -14,7 +14,7 @@ else {
     die "Usage: `$*PROGRAM_NAME <file>` or `$*PROGRAM_NAME -e '<program>'`";
 }
 
-my $origprogram = $program; # in case we need the original copy later
+my $origprog = $program; # in case we need the original copy later
 
 my @ticks;
 run-program();
@@ -49,8 +49,11 @@ while defined(my $cmd = prompt "TICK $current-tick/{@ticks.end}> ") {
         when 'look'          { look() }
         when 'step'          { step() }
         when 'n'             { step() }
+        when 'pets'          { pets() }
+        when 'p'             { pets() }
         when /^ go \s+ (\d+) $/  { go(+$0) }
         when /^ rewrite \s+ (.+) $/ { rewrite(~$0) }
+        when 'unwrite'       { unwrite() }
         when /^ help [\s+ (\N+)]? $/ { help(~$0) }
         when 'quit'          { quit() }
         when 'q'             { quit() }
@@ -77,6 +80,15 @@ sub step() {
     look();
 }
 
+sub pets() {
+    if $current-tick == 0 {
+        say 'Can not go beyond the zeroth tick.';
+        return;
+    }
+    --$current-tick;
+    look();
+}
+
 # RAKUDO: Should really be typed 'Int'.
 multi sub go(Num $tick where { $tick > @ticks.end }) {
     say 'Can not go beyond last tick.';
@@ -92,6 +104,7 @@ sub rewrite(Str $line is copy) {
     }
     if $current-tick == 0 {
         say 'You cannot rewrite tick 0; this is the "before execution" tick.';
+        return;
     }
     my @proglines = $program.split(';');
     @proglines[$current-tick - 1] = $line;
@@ -101,19 +114,38 @@ sub rewrite(Str $line is copy) {
     say "No paradoxes occurred. You may continue.";
 }
 
+sub unwrite() {
+    if $current-tick == 0 {
+        say 'You cannot unwrite tick 0. [Changing tick 0 is quite an accomplishment if you managed it, by the way.]';
+        return;
+    }
+    my @proglines = $program.split(';');
+    my @oldprog   = $origprog.split(';');
+    @proglines[$current-tick - 1] = @oldprog[$current-tick - 1];
+    $program = @proglines.join(';');
+    say "Unwrite of tick $current-tick successful. Rewriting time...";
+    run-program();
+    say "Time seems to be alright. You may continue.";
+}
+
 sub help($topic) {
     given $topic {
         when "look" { say "syntax: look
     when this command is executed, Tardis will look at all the variables in your program at that particular tick and show you their values. Many other commands in Tardis will run `look' at some point."; }
         when "step" { say "syntax: step
     This command will go to the next tick in the program. Afterwards, `look' will be run so you can see what happens at this moment in time. If you reached the end of the timeline, the command will stop and let you continue using Tardis. This command is equivalent to go 1."; }
+        when "pets" { say "syntax: pets
+    This command does the opposite of step (hence 'pets'), and goes one back. After doing so, it will `look'."; }
         when "go" { say "syntax: go N    where N is a number.
     `go' will jump to a specific tick in the timeline. If the point you wish to jump to is beyond the range of the timeline, the command will quit running (for the program you put in Tardis, this range is 0..{@ticks.end}). Tardis will still be running however. After jumping to that specific tick in the timeline, the command will `look'."; }
         when "rewrite" { say "syntax: rewrite STRING
     The `rewrite' command will rewrite the current tick with STRING. Afterwards, the program will be recompiled and rerun. Invalid P6 code will stop Tardis from running."; }
+        when "unwrite" { say "syntax: unwrite
+    The `unwrite' command will revert the current tick to what it was in its original form."; }
         when "help" { say "syntax: help [COMMAND]
     This displays help information for COMMAND. If no COMMAND is specified, a list of all the available commands and a brief list of what each command does."; }
-        #XXX add quit/exit/q help, although the need for anything more complex than what the overview says is questionable.
+        when "quit" { say "syntax: quit
+    This command will stop Tardis and return you to your shell."; }
         default { say "Tardis debugging commands:
 look    View the state of all variables in the program.
 step    Goes to the next tick in the program, then `look's.
@@ -133,6 +165,7 @@ sub quit() {
 
 sub debug() {
     say "Tardis DEBUG INFO (for Tardis devs):
-{$program.perl}
-{@ticks.perl}";
+Current program input: {$program.perl}
+           (original): {$origprog.perl}
+                Ticks: {@ticks.perl}";
 }


### PR DESCRIPTION
Here I have added some extra commands for the Tardis commandline. Here is a quick overview:

help — this command gives you help on various commands of the program. If you type a command after help, you'll get detailed info on that command.

pets — It does the opposite of step, and jumps one back in the program. (I thought `pets' was much cooler than`unstep')

rewrite CODE — This lets you rewrite the current tick to contain CODE, then recompiles and reruns the program.

unwrite — This will unwrite the current tick you're on. In other words, it takes the appropriate tick from the original program and overwrites what that tick currently holds.

It's not perfect (I can imagine things breaking if you use rewrite and turn one tick into two), but in my opinion it's good enough to be put into the main program.
