### PR TITLE
Replace repo-url with source-url in metainfo

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,5 +4,5 @@
     "description" : "Time traveling debugger in Perl 6",
     "depends"     : ["Yapsi"],
     "repo-type"   : "git",
-    "repo-url"    : "git://github.com/masak/tardis.git"
+    "source-url"    : "git://github.com/masak/tardis.git"
 }


### PR DESCRIPTION
`repo-url` has been obsolete for some time (this was found out after a
discussion with tadzik on irc) and has been replaced by `source-url`.  This
change updates the metainfo appropriately.
