### PR TITLE
Add Required provides to the META

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,6 +3,9 @@
     "version"     : "*",
     "description" : "Time traveling debugger in Perl 6",
     "depends"     : ["Yapsi"],
+    "provides"    : {
+       "Tardis" : "lib/Tardis.pm"
+    },
     "repo-type"   : "git",
     "repo-url"    : "git://github.com/masak/tardis.git"
 }


### PR DESCRIPTION
Hi,
was just surveying the warnings from the modules "indexer"

```
[Wed Oct 26 18:25:26 2016] [info] Processing dist 72 of 739
[Wed Oct 26 18:25:26 2016] [info] Using ModulesPerl6::DbBuilder::Dist::Source::GitHub to load https://raw.githubusercontent.com/masak/tardis/master/META.info
[Wed Oct 26 18:25:26 2016] [info] Fetching distro info and commits
[Wed Oct 26 18:25:26 2016] [info] Downloading META file from https://raw.githubusercontent.com/masak/tardis/master/META.info
[Wed Oct 26 18:25:26 2016] [info] Parsing META file
[Wed Oct 26 18:25:26 2016] [warn] Required `perl` field is missing
[Wed Oct 26 18:25:26 2016] [warn] Required `provides` field is missing
[Wed Oct 26 18:25:27 2016] [info] dist source URL is same as META repo URL (https://github.com/masak/tardis)

```

There is already a PR for the 'perl' version :)
